### PR TITLE
Allow skipping unsupported ring flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axboe-liburing"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fbf17555205e22187d2eaf8b3d844a4865adfb822b65e6afb3815c861e6a47"
+checksum = "e12f708ef12a68e679972dd7de245e616b18ea4f4a740ba22079232fe9e99752"
 dependencies = [
  "bindgen",
 ]
@@ -999,21 +999,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "i2o2"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axboe-liburing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i2o2"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "A io_uring based IO executor for sync and async runtimes"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ slab = "0.4"
 tracing = "0.1"
 parking_lot = "0.12"
 crossbeam-queue = "0.3"
-axboe-liburing = "2.11.0"
+axboe-liburing = "2.12"
 
 tokio = { version = "1", features = ["sync"] }
 
@@ -31,7 +31,7 @@ tokio = { version = "1", features = ["sync"] }
 fail = { version = "0.5.1", features = ["failpoints"], optional = true }
 
 [dev-dependencies]
-rstest = "0.25"
+rstest = "0.26"
 tempfile = "3.20"
 tracing-subscriber = "0.3.19"
 memmap2 = "0.9.5"

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -98,7 +98,6 @@ impl RingProbe {
     pub fn is_kernel_v5_19_or_newer(&self) -> bool {
         #[cfg(test)]
         {
-            eprintln!("{:?}", std::env::var("FAILPOINTS"));
             fail::fail_point!("kernel_v5_13", |_| false);
             fail::fail_point!("kernel_v5_15", |_| false);
             fail::fail_point!("kernel_v5_18", |_| false);

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -24,7 +24,7 @@ pub(super) struct IoRing {
 impl IoRing {
     #[cfg(test)]
     pub(super) fn for_test(queue_size: u32) -> io::Result<Self> {
-        Self::new(queue_size, unsafe { std::mem::zeroed() })
+        Self::new(queue_size, unsafe { mem::zeroed() })
     }
 
     /// Creates a new ring using the given queue size and flags.
@@ -219,7 +219,7 @@ impl<'ring> Iterator for CqeIterator<'ring> {
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            let mut cqe = std::ptr::null_mut::<io_uring_cqe>();
+            let mut cqe = ptr::null_mut::<io_uring_cqe>();
             let did_read = io_uring_cqe_iter_next(&raw mut self.iter, &raw mut cqe);
             if !did_read {
                 None

--- a/src/tests/creation.rs
+++ b/src/tests/creation.rs
@@ -58,6 +58,10 @@ use crate::I2o2Builder;
         .with_sqe_size128(true)
         .with_num_registered_files(64)
 )]
+#[case::with_size128_register_files(
+    crate::builder()
+        .skip_unsupported_features(true)
+)]
 fn test_scheduler_creation(#[case] builder: I2o2Builder) {
     let (_scheduler, _handle) = builder
         .try_create::<()>()
@@ -96,6 +100,12 @@ fn test_scheduler_creation(#[case] builder: I2o2Builder) {
 #[case::failpoint_kernel_v5_19_registered_buffers(crate::builder().with_num_registered_buffers(8))]
 #[case::failpoint_kernel_v6_0_registered_buffers(crate::builder().with_num_registered_buffers(8))]
 #[case::failpoint_kernel_v6_1_registered_buffers(crate::builder().with_num_registered_buffers(8))]
+#[should_panic]
+#[case::failpoint_kernel_v5_13_skip_unsupported_features(crate::builder().with_coop_task_run(true).skip_unsupported_features(true))]
+#[case::failpoint_kernel_v5_15_skip_unsupported_features(crate::builder().with_coop_task_run(true).skip_unsupported_features(true))]
+#[case::failpoint_kernel_v5_19_skip_unsupported_features(crate::builder().with_coop_task_run(true).skip_unsupported_features(true))]
+#[case::failpoint_kernel_v6_0_unsupported_features(crate::builder().with_coop_task_run(true).skip_unsupported_features(true))]
+#[case::failpoint_kernel_v6_1_unsupported_features(crate::builder().with_coop_task_run(true).skip_unsupported_features(true))]
 // -- Begin size 128 tests
 #[should_panic]
 #[case::size128_failpoint_kernel_v5_13_default(crate::builder().with_sqe_size128(true))]
@@ -110,12 +120,12 @@ fn test_scheduler_creation(#[case] builder: I2o2Builder) {
 #[case::size128_failpoint_kernel_v6_0_io_polling(crate::builder().with_sqe_size128(true).with_io_polling(true))]
 #[case::size128_failpoint_kernel_v6_1_io_polling(crate::builder().with_sqe_size128(true).with_io_polling(true))]
 #[should_panic]
-#[case::size128_failpoint_kernel_v5_13_defer_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
+#[case::size128_failpoint_kernel_v5_13_coop_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
 #[should_panic]
-#[case::size128_failpoint_kernel_v5_15_defer_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
-#[case::size128_failpoint_kernel_v5_19_defer_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
-#[case::size128_failpoint_kernel_v6_0_defer_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
-#[case::size128_failpoint_kernel_v6_1_defer_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
+#[case::size128_failpoint_kernel_v5_15_coop_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
+#[case::size128_failpoint_kernel_v5_19_coop_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
+#[case::size128_failpoint_kernel_v6_0_coop_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
+#[case::size128_failpoint_kernel_v6_1_coop_task_run(crate::builder().with_sqe_size128(true).with_coop_task_run(true))]
 #[should_panic]
 #[case::size128_failpoint_kernel_v5_13_registered_files(crate::builder().with_sqe_size128(true).with_num_registered_files(8))]
 #[case::size128_failpoint_kernel_v5_15_registered_files(crate::builder().with_sqe_size128(true).with_num_registered_files(8))]


### PR DESCRIPTION
Allows the user to enable ring flags, but skip them if the kernel does not support it.