### PR TITLE
Feat: Add defer task run with ring messaging replacing eventfd

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,8 @@
 experimental = ["setup-scripts"]
 
+[profile.default]
+slow-timeout = { period = "10s", terminate-after = 2 }
+
 [[profile.default.scripts]]
 filter = "test(/failpoint_kernel_v5_13_/)"
 setup = "failpoint_kernel_v5_13"

--- a/benches/direct_io_random_read.rs
+++ b/benches/direct_io_random_read.rs
@@ -104,7 +104,7 @@ fn run_glommio_benches(
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn run_i2o2_benches(
     file_manager: &mut FileManager,
     results: &mut BenchmarkRandomReadResults,

--- a/benches/direct_io_random_read.rs
+++ b/benches/direct_io_random_read.rs
@@ -47,11 +47,11 @@ fn main() -> Result<()> {
     run_i2o2_benches(&mut file_manger, &mut results)?;
     std::thread::sleep(Duration::from_secs(20));
 
-    // run_std_benches(&mut file_manger, &mut results)?;
-    // std::thread::sleep(Duration::from_secs(20));
-    //
-    // run_glommio_benches(&mut file_manger, &mut results)?;
-    // std::thread::sleep(Duration::from_secs(20));
+    run_std_benches(&mut file_manger, &mut results)?;
+    std::thread::sleep(Duration::from_secs(20));
+
+    run_glommio_benches(&mut file_manger, &mut results)?;
+    std::thread::sleep(Duration::from_secs(20));
 
     tracing::info!("done!");
 

--- a/benches/direct_io_random_read.rs
+++ b/benches/direct_io_random_read.rs
@@ -30,7 +30,7 @@ static BASE_PATH: &str = "./benchmark-data/benchmark-xfs";
 const BUFFER_SIZE: usize = 8 << 10;
 const RUN_DURATION: Duration = Duration::from_secs(15);
 const THREADED_CONCURRENCY_LEVELS: [usize; 4] = [1, 64, 256, 512];
-const ASYNC_CONCURRENCY_LEVELS: [usize; 5] = [1, 64, 1024, 2048, 4096];
+const ASYNC_CONCURRENCY_LEVELS: [usize; 4] = [1, 64, 2048, 4096];
 
 const PIN_SCHEDULER_THREAD_TO_CORE: u32 = 5;
 const SIZE_100GB: usize = 100 << 30;
@@ -47,11 +47,11 @@ fn main() -> Result<()> {
     run_i2o2_benches(&mut file_manger, &mut results)?;
     std::thread::sleep(Duration::from_secs(20));
 
-    run_std_benches(&mut file_manger, &mut results)?;
-    std::thread::sleep(Duration::from_secs(20));
-
-    run_glommio_benches(&mut file_manger, &mut results)?;
-    std::thread::sleep(Duration::from_secs(20));
+    // run_std_benches(&mut file_manger, &mut results)?;
+    // std::thread::sleep(Duration::from_secs(20));
+    //
+    // run_glommio_benches(&mut file_manger, &mut results)?;
+    // std::thread::sleep(Duration::from_secs(20));
 
     tracing::info!("done!");
 

--- a/benches/no_op_throughput_async.rs
+++ b/benches/no_op_throughput_async.rs
@@ -10,7 +10,7 @@ mod no_op_shared;
 
 const NUM_OPS_PER_WORKER: usize = 100_000;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> io::Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -63,7 +63,6 @@ async fn bench_with_config(
                 let result = reply.await;
                 assert_eq!(result, Ok(0));
             }
-
             Ok::<_, io::Error>(0)
         });
 

--- a/examples/fail_points.rs
+++ b/examples/fail_points.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::sync::Arc;
 
 #[cfg_attr(test, test)]
 fn main() -> io::Result<()> {
@@ -36,6 +35,7 @@ fn main() -> io::Result<()> {
         .join()
         .expect("scheduler should never panic")?;
 
+    scenario.teardown();
     println!("scheduler shutdown complete!");
 
     Ok(())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -237,6 +237,7 @@ impl I2o2Builder {
             waker,
             incoming_ops: io_queue_rx,
             incoming_resources: resource_queue_rx,
+            last_read_work_counter: 0,
             _anti_send_ptr: std::ptr::null_mut(),
         };
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -298,6 +298,10 @@ impl I2o2Builder {
             params.flags |= IORING_SETUP_SINGLE_ISSUER;
         }
 
+        if probe.is_kernel_v6_1_or_newer() {
+            params.flags |= IORING_SETUP_DEFER_TASKRUN;
+        }
+
         if self.io_poll {
             params.flags |= IORING_SETUP_IOPOLL;
         }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -7,6 +7,7 @@ pub const GUARDED: u64 = 0x2000_0000_0000_0000;
 pub const GUARDED_RESOURCE_BUFFER: u64 = 0x3000_0000_0000_0000;
 pub const GUARDED_RESOURCE_FILE: u64 = 0x4000_0000_0000_0000;
 pub const FILLER_OP: u64 = 0x5000_0000_0000_0000;
+pub const WAKE: u64 = 0x6000_0000_0000_0000;
 
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -25,6 +26,8 @@ pub enum Flag {
     /// A no-op used to ensure there is a valid op submitted when the incoming queue
     /// returns `None` after we have acquired a new SQE.
     FillerOp = FILLER_OP,
+    /// The operation is a wake message and is effectively a no-op.
+    Wake = WAKE,
 }
 
 /// Packs the 4 bit `flag` with the 30 bit `reply_idx` and `guard_idx`.
@@ -57,6 +60,7 @@ pub fn unpack(packed_value: u64) -> (Flag, u32, u32) {
         GUARDED_RESOURCE_BUFFER => Flag::GuardedResourceBuffer,
         GUARDED_RESOURCE_FILE => Flag::GuardedResourceFile,
         FILLER_OP => Flag::FillerOp,
+        WAKE => Flag::Wake,
         // This should **never** happen, if this occurs the system has
         // already entered a UB state since we have to assume that any or all of
         // our prior event reads and unpacking are invalid; which means we have

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -8,6 +8,7 @@ pub const GUARDED_RESOURCE_BUFFER: u64 = 0x3000_0000_0000_0000;
 pub const GUARDED_RESOURCE_FILE: u64 = 0x4000_0000_0000_0000;
 pub const FILLER_OP: u64 = 0x5000_0000_0000_0000;
 pub const WAKE: u64 = 0x6000_0000_0000_0000;
+pub const DRAIN: u64 = 0x7000_0000_0000_0000;
 
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -28,6 +29,8 @@ pub enum Flag {
     FillerOp = FILLER_OP,
     /// The operation is a wake message and is effectively a no-op.
     Wake = WAKE,
+    /// The final operation in the ring.
+    Drain = DRAIN,
 }
 
 /// Packs the 4 bit `flag` with the 30 bit `reply_idx` and `guard_idx`.
@@ -61,6 +64,7 @@ pub fn unpack(packed_value: u64) -> (Flag, u32, u32) {
         GUARDED_RESOURCE_FILE => Flag::GuardedResourceFile,
         FILLER_OP => Flag::FillerOp,
         WAKE => Flag::Wake,
+        DRAIN => Flag::Drain,
         // This should **never** happen, if this occurs the system has
         // already entered a UB state since we have to assume that any or all of
         // our prior event reads and unpacking are invalid; which means we have

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -436,7 +436,7 @@ where
         message: Packaged<opcode::AnyOp, G>,
     ) -> Result<(), SchedulerClosed> {
         self.ops_queue.send(message).map_err(|_| SchedulerClosed)?;
-        self.waker.maybe_wake();
+        self.waker.signal_work_added();
         Ok(())
     }
 
@@ -448,7 +448,7 @@ where
             .send_async(message)
             .await
             .map_err(|_| SchedulerClosed)?;
-        self.waker.maybe_wake();
+        self.waker.signal_work_added();
         Ok(())
     }
 
@@ -459,7 +459,7 @@ where
         self.resource_queue
             .send(message)
             .map_err(|_| SchedulerClosed)?;
-        self.waker.maybe_wake();
+        self.waker.signal_work_added();
         Ok(())
     }
 
@@ -471,7 +471,7 @@ where
             .send_async(message)
             .await
             .map_err(|_| SchedulerClosed)?;
-        self.waker.maybe_wake();
+        self.waker.signal_work_added();
         Ok(())
     }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -42,7 +42,7 @@ pub enum RegisterError {
 pub struct I2o2Handle<G = DynamicGuard> {
     ops_queue: super::queue::SchedulerSender<Packaged<opcode::AnyOp, G>>,
     resource_queue: super::queue::SchedulerSender<ResourceMessage<G>>,
-    waker: super::wake::RingWaker,
+    waker: super::wake::Waker,
 }
 
 impl<G> Clone for I2o2Handle<G> {
@@ -59,7 +59,7 @@ impl<G> I2o2Handle<G> {
     pub(super) fn new(
         ops_queue: super::queue::SchedulerSender<Packaged<opcode::AnyOp, G>>,
         resource_queue: super::queue::SchedulerSender<ResourceMessage<G>>,
-        waker: super::wake::RingWaker,
+        waker: super::wake::Waker,
     ) -> Self {
         Self {
             ops_queue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use std::{io, mem};
 
 use liburing_rs::{
     IOSQE_IO_DRAIN,
-    io_uring_prep_nop,
     io_uring_sqe,
     io_uring_sqe_set_data64,
     io_uring_sqe_set_flags,
@@ -206,7 +205,7 @@ impl<G> I2o2Scheduler<G> {
                     "rejecting op because size128 is required but not active"
                 );
                 write_filler_op(sqe);
-                let _ = msg.reply.set_result(MAGIC_ERRNO_NOT_SIZE128);
+                msg.reply.set_result(MAGIC_ERRNO_NOT_SIZE128);
                 continue;
             }
 
@@ -456,10 +455,6 @@ impl<G> TrackedState<G> {
 
     fn has_seen_drain_op(&self) -> bool {
         self.seen_drain_op
-    }
-
-    fn remaining_tasks(&self) -> usize {
-        self.replies.len()
     }
 
     fn handle_cqe(&mut self, user_data: u64, result: i32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,16 +275,10 @@ impl<G> I2o2Scheduler<G> {
         #[cfg(feature = "trace-hotpath")]
         tracing::trace!("no work, scheduler waiting on events...");
 
-        let mut cqe = std::ptr::null_mut();
-        self.ring.wait_for_completions(&raw mut cqe)?;
+        self.ring.wait_for_completions()?;
 
         #[cfg(feature = "trace-hotpath")]
         tracing::trace!("woken");
-
-        if !cqe.is_null() {
-            let cqe = unsafe { &*cqe };
-            self.state.handle_cqe(cqe.user_data, cqe.res);
-        }
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 use std::io;
-
+use std::sync::atomic::Ordering;
 use liburing_rs::{io_uring_sqe, io_uring_sqe_set_data64};
 
 use crate::opcode::sealed::RegisterOp;
@@ -281,7 +281,6 @@ impl<G> I2o2Scheduler<G> {
         if !self.has_outstanding_work() {
             self.waker.ask_for_wake();
 
-            // Check again because of atomics, yada, yada...
             if !self.has_outstanding_work() {
                 return Ok(());
             }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -188,6 +188,15 @@ enum TrySendError<T> {
 mod tests {
 
     #[test]
+    fn test_queue_disconnect() {
+        let (tx, rx) = super::new::<()>(9);
+
+        assert!(!rx.is_disconnected());
+        drop(tx);
+        assert!(rx.is_disconnected());
+    }
+
+    #[test]
     fn test_queue_sync_handling() {
         let _ = tracing_subscriber::fmt::try_init();
 

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -191,11 +191,9 @@ impl IoRing {
     }
 
     /// Wait for at least 1 completion event to be ready.
-    pub(super) fn wait_for_completions(
-        &mut self,
-        cqe: *mut *mut io_uring_cqe,
-    ) -> io::Result<()> {
-        let result = unsafe { io_uring_wait_cqe(&raw mut self.ring, cqe) };
+    pub(super) fn wait_for_completions(&mut self) -> io::Result<()> {
+        let mut cqe = ptr::null_mut();
+        let result = unsafe { io_uring_wait_cqe(&raw mut self.ring, &raw mut cqe) };
         check_err!(result)
     }
 

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,4 +1,6 @@
 use std::io::ErrorKind;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, mem, ptr};
 
 use liburing_rs::*;
@@ -18,7 +20,7 @@ macro_rules! check_err {
 pub(super) struct IoRing {
     ring: io_uring,
     probe: RingProbe,
-    closed: bool,
+    closed: Arc<AtomicBool>,
 }
 
 impl IoRing {
@@ -55,14 +57,16 @@ impl IoRing {
         Ok(Self {
             ring,
             probe,
-            closed: false,
+            closed: Arc::new(AtomicBool::new(false)),
         })
     }
 
-    /// Register an eventfd with the ring.
-    pub(super) fn register_eventfd(&mut self, fd: libc::c_int) -> io::Result<()> {
-        let result = unsafe { io_uring_register_eventfd(&raw mut self.ring, fd) };
-        check_err!(result)
+    /// Creates a new [RingWaker] for the ring.
+    pub(super) fn create_waker(&self) -> RingWaker {
+        RingWaker {
+            ring_fd: self.ring.ring_fd,
+            closed: self.closed.clone(),
+        }
     }
 
     /// Preallocate a sparse set of files.
@@ -186,7 +190,6 @@ impl IoRing {
         Ok(result as usize)
     }
 
-    #[cfg(test)]
     /// Submit any outstanding submissions to the kernel and wait for at least
     /// 1 completion event to be ready.
     pub(super) fn submit_and_wait_one(&mut self) -> io::Result<()> {
@@ -197,13 +200,14 @@ impl IoRing {
 
 impl Drop for IoRing {
     fn drop(&mut self) {
-        if !self.closed {
+        let is_closed = self.closed.load(Ordering::Acquire);
+        if !is_closed {
             let result = unsafe { io_uring_close_ring_fd(&raw mut self.ring) };
             if result < 0 {
                 let err = io::Error::from_raw_os_error(-result);
                 tracing::error!(error = %err, "cannot shutdown ring");
             } else {
-                self.closed = true;
+                self.closed.store(true, Ordering::Release);
             }
         }
     }
@@ -231,6 +235,36 @@ impl<'ring> Iterator for CqeIterator<'ring> {
                 self.ring.advance_seen_cqe(cqe);
                 Some(entry)
             }
+        }
+    }
+}
+
+/// The ring waker allows threads outside the main scheduler thread
+/// to wake up the scheduler by sending a message to the ring.
+pub(super) struct RingWaker {
+    ring_fd: libc::c_int,
+    closed: Arc<AtomicBool>,
+}
+
+impl RingWaker {
+    /// Signals whether the ring the waker belongs to is closed.
+    pub(super) fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// Wake the ring.
+    ///
+    /// Returns `true` if the ring was successfully woken.
+    pub(super) fn wake(&self, user_data: u64) -> bool {
+        if !self.is_closed() {
+            let result = unsafe {
+                let mut sqe = mem::zeroed::<io_uring_sqe>();
+                io_uring_prep_msg_ring(&raw mut sqe, self.ring_fd, 0x01, user_data, 0);
+                io_uring_register_sync_msg(&raw mut sqe)
+            };
+            result >= 0
+        } else {
+            false
         }
     }
 }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -191,7 +191,10 @@ impl IoRing {
     }
 
     /// Wait for at least 1 completion event to be ready.
-    pub(super) fn wait_for_completions(&mut self, cqe: *mut *mut io_uring_cqe) -> io::Result<()> {
+    pub(super) fn wait_for_completions(
+        &mut self,
+        cqe: *mut *mut io_uring_cqe,
+    ) -> io::Result<()> {
         let result = unsafe { io_uring_wait_cqe(&raw mut self.ring, cqe) };
         check_err!(result)
     }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -190,6 +190,13 @@ impl IoRing {
         Ok(result as usize)
     }
 
+    /// Wait for at least 1 completion event to be ready.
+    pub(super) fn wait_for_completions(&mut self, cqe: *mut *mut io_uring_cqe) -> io::Result<()> {
+        let result = unsafe { io_uring_wait_cqe(&raw mut self.ring, cqe) };
+        check_err!(result)
+    }
+
+    #[cfg(test)]
     /// Submit any outstanding submissions to the kernel and wait for at least
     /// 1 completion event to be ready.
     pub(super) fn submit_and_wait_one(&mut self) -> io::Result<()> {

--- a/src/wake.rs
+++ b/src/wake.rs
@@ -61,7 +61,6 @@ impl WakerInner {
     }
 
     fn maybe_wake(&self) -> bool {
-        std::sync::atomic::fence(Ordering::AcqRel);
         let wants_wake = self.wants_wake.swap(false, Ordering::AcqRel);
         #[cfg(feature = "trace-hotpath")]
         tracing::trace!(wants_wake = wants_wake, "waking ring");


### PR DESCRIPTION
Adds automatic enabling of `IORING_SETUP_DEFER_TASKRUN` on supported kernels.

To support this, we've moved from eventfd-based waking to ring messaging, which also comes with a nice ~3-4x improvement in latency when the system is not hot and has to repeatedly park and unpark the scheduler.